### PR TITLE
Remove authentication from registration

### DIFF
--- a/src/modules/user/user.routes.ts
+++ b/src/modules/user/user.routes.ts
@@ -7,7 +7,7 @@ const router = Router({ mergeParams: false });
 
 router
   .route('/')
-  .post(authenticate, validateRequest(createUserRequestSchema), createUser);
+  .post(validateRequest(createUserRequestSchema), createUser);
 
 export default router;
 


### PR DESCRIPTION
Fixes bug that requires you to be authenticated to be able to register as a new user.
- Remove `authenticate` middleware from the create-user route